### PR TITLE
Remove CustomDimensions plugin leftovers

### DIFF
--- a/apache/common.config.ini.php
+++ b/apache/common.config.ini.php
@@ -4,8 +4,6 @@ proxy_host_headers[] = HTTP_X_FORWARDED_HOST
 
 [Plugins]
 Plugins[] = "EnvironmentVariables"
-Plugins[] = "CustomDimensions"
 
 [PluginsInstalled]
 PluginsInstalled[] = "EnvironmentVariables"
-PluginsInstalled[] = "CustomDimensions"

--- a/common.config.ini.php
+++ b/common.config.ini.php
@@ -4,8 +4,6 @@ proxy_host_headers[] = HTTP_X_FORWARDED_HOST
 
 [Plugins]
 Plugins[] = "EnvironmentVariables"
-Plugins[] = "CustomDimensions"
 
 [PluginsInstalled]
 PluginsInstalled[] = "EnvironmentVariables"
-PluginsInstalled[] = "CustomDimensions"

--- a/fpm-alpine/common.config.ini.php
+++ b/fpm-alpine/common.config.ini.php
@@ -4,8 +4,6 @@ proxy_host_headers[] = HTTP_X_FORWARDED_HOST
 
 [Plugins]
 Plugins[] = "EnvironmentVariables"
-Plugins[] = "CustomDimensions"
 
 [PluginsInstalled]
 PluginsInstalled[] = "EnvironmentVariables"
-PluginsInstalled[] = "CustomDimensions"

--- a/fpm/common.config.ini.php
+++ b/fpm/common.config.ini.php
@@ -4,8 +4,6 @@ proxy_host_headers[] = HTTP_X_FORWARDED_HOST
 
 [Plugins]
 Plugins[] = "EnvironmentVariables"
-Plugins[] = "CustomDimensions"
 
 [PluginsInstalled]
 PluginsInstalled[] = "EnvironmentVariables"
-PluginsInstalled[] = "CustomDimensions"


### PR DESCRIPTION
CustomDimensions before matomo 4.0 was an extension that to be used, should be installed from the marketplace (https://plugins.matomo.org/CustomDimensions?piwikversion=2). After version 4.0, this plugin is provided out-of-the-box with Matomo vanilla installation.

This PR removes the CustomDimensions plugin installation leftovers (commit: 'Raise PHP Memory Limit and Remove custom dimensions SQL, id: 750ffc4e07c6ff14a6c39d251e042ab2e3dbcec3) on the common.config.ini.php file, allowing the installing of Matomo without issues. The clean installation is broken since matomo 4.0.0.